### PR TITLE
CardAction tests

### DIFF
--- a/CardBox.xcodeproj/project.pbxproj
+++ b/CardBox.xcodeproj/project.pbxproj
@@ -16,18 +16,18 @@
 		2D007F9227E4599000F0E359 /* ExtendedProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D007F9127E4599000F0E359 /* ExtendedProperties.swift */; };
 		2D007F9D27E45B9A00F0E359 /* NextPlayerGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D007F9C27E45B9A00F0E359 /* NextPlayerGenerator.swift */; };
 		2D007FA227E45D6000F0E359 /* ExplodingKittensNextPlayerGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D007FA127E45D6000F0E359 /* ExplodingKittensNextPlayerGenerator.swift */; };
-		2D00812327E6155100F0E359 /* WinningCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D00812227E6155100F0E359 /* WinningCondition.swift */; };
-		2D00812C27E617A700F0E359 /* LastStandWinningCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D00812B27E617A700F0E359 /* LastStandWinningCondition.swift */; };
-		2D00813127E6193400F0E359 /* WinnerGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D00813027E6193400F0E359 /* WinnerGenerator.swift */; };
-		2D00813627E61AA700F0E359 /* LastStandWinnerGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D00813527E61AA700F0E359 /* LastStandWinnerGenerator.swift */; };
-		2D00816B27E64C8A00F0E359 /* WinMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D00816A27E64C8A00F0E359 /* WinMessageView.swift */; };
 		2D0080D927E5D07000F0E359 /* SetPlayerAdditionalParamsCardAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D0080D827E5D07000F0E359 /* SetPlayerAdditionalParamsCardAction.swift */; };
 		2D0080DE27E5D0DD00F0E359 /* SetPlayerAdditionalParamsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D0080DD27E5D0DD00F0E359 /* SetPlayerAdditionalParamsEvent.swift */; };
 		2D0080E627E5DB5500F0E359 /* SetPlayerAdditionalParamsAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D0080E527E5DB5500F0E359 /* SetPlayerAdditionalParamsAction.swift */; };
 		2D0080FA27E602C900F0E359 /* StepAdditionalParamsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D0080F927E602C900F0E359 /* StepAdditionalParamsEvent.swift */; };
 		2D0080FF27E6048600F0E359 /* StepAdditionalParamsCardAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D0080FE27E6048600F0E359 /* StepAdditionalParamsCardAction.swift */; };
 		2D00811227E608EA00F0E359 /* StepAdditionalParamsAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D00811127E608EA00F0E359 /* StepAdditionalParamsAction.swift */; };
+		2D00812327E6155100F0E359 /* WinningCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D00812227E6155100F0E359 /* WinningCondition.swift */; };
+		2D00812C27E617A700F0E359 /* LastStandWinningCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D00812B27E617A700F0E359 /* LastStandWinningCondition.swift */; };
+		2D00813127E6193400F0E359 /* WinnerGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D00813027E6193400F0E359 /* WinnerGenerator.swift */; };
+		2D00813627E61AA700F0E359 /* LastStandWinnerGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D00813527E61AA700F0E359 /* LastStandWinnerGenerator.swift */; };
 		2D00815027E6253200F0E359 /* PlayerCollectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D00814F27E6253200F0E359 /* PlayerCollectionTests.swift */; };
+		2D00816B27E64C8A00F0E359 /* WinMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D00816A27E64C8A00F0E359 /* WinMessageView.swift */; };
 		2D00817927E6D1CA00F0E359 /* CardCollectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D00817827E6D1CA00F0E359 /* CardCollectionTests.swift */; };
 		2DA04F3327DADD500063D952 /* CardBoxApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DA04F3227DADD500063D952 /* CardBoxApp.swift */; };
 		2DA04F3527DADD500063D952 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DA04F3427DADD500063D952 /* ContentView.swift */; };
@@ -119,6 +119,8 @@
 		4ECD77E627E6E65500A48FA7 /* ActionTests+MoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ECD77E527E6E65400A48FA7 /* ActionTests+MoreTests.swift */; };
 		4ECD77E827E70A5A00A48FA7 /* CardActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ECD77E727E70A5A00A48FA7 /* CardActionTests.swift */; };
 		4ECD77EA27E70B2300A48FA7 /* CardActionTests+NextPlayerGeneratorStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ECD77E927E70B2300A48FA7 /* CardActionTests+NextPlayerGeneratorStub.swift */; };
+		4ECD77EC27E73A9900A48FA7 /* CardBoxTestsUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ECD77EB27E73A9900A48FA7 /* CardBoxTestsUtil.swift */; };
+		4ECD77EE27E7427000A48FA7 /* CardActionTests+MoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ECD77ED27E7427000A48FA7 /* CardActionTests+MoreTests.swift */; };
 		682AA3CD27DF1EB90034ED90 /* AddCardToPlayerAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 682AA3CC27DF1EB90034ED90 /* AddCardToPlayerAction.swift */; };
 		68466A8F27E5061B000387B6 /* CurrentPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68466A8E27E5061B000387B6 /* CurrentPlayerView.swift */; };
 		68466A9127E506C2000387B6 /* NonCurrentPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68466A9027E506C2000387B6 /* NonCurrentPlayerView.swift */; };
@@ -159,18 +161,18 @@
 		2D007F9127E4599000F0E359 /* ExtendedProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtendedProperties.swift; sourceTree = "<group>"; };
 		2D007F9C27E45B9A00F0E359 /* NextPlayerGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextPlayerGenerator.swift; sourceTree = "<group>"; };
 		2D007FA127E45D6000F0E359 /* ExplodingKittensNextPlayerGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExplodingKittensNextPlayerGenerator.swift; sourceTree = "<group>"; };
-		2D00812227E6155100F0E359 /* WinningCondition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WinningCondition.swift; sourceTree = "<group>"; };
-		2D00812B27E617A700F0E359 /* LastStandWinningCondition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastStandWinningCondition.swift; sourceTree = "<group>"; };
-		2D00813027E6193400F0E359 /* WinnerGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WinnerGenerator.swift; sourceTree = "<group>"; };
-		2D00813527E61AA700F0E359 /* LastStandWinnerGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastStandWinnerGenerator.swift; sourceTree = "<group>"; };
-		2D00816A27E64C8A00F0E359 /* WinMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WinMessageView.swift; sourceTree = "<group>"; };
 		2D0080D827E5D07000F0E359 /* SetPlayerAdditionalParamsCardAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetPlayerAdditionalParamsCardAction.swift; sourceTree = "<group>"; };
 		2D0080DD27E5D0DD00F0E359 /* SetPlayerAdditionalParamsEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetPlayerAdditionalParamsEvent.swift; sourceTree = "<group>"; };
 		2D0080E527E5DB5500F0E359 /* SetPlayerAdditionalParamsAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetPlayerAdditionalParamsAction.swift; sourceTree = "<group>"; };
 		2D0080F927E602C900F0E359 /* StepAdditionalParamsEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepAdditionalParamsEvent.swift; sourceTree = "<group>"; };
 		2D0080FE27E6048600F0E359 /* StepAdditionalParamsCardAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepAdditionalParamsCardAction.swift; sourceTree = "<group>"; };
 		2D00811127E608EA00F0E359 /* StepAdditionalParamsAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepAdditionalParamsAction.swift; sourceTree = "<group>"; };
+		2D00812227E6155100F0E359 /* WinningCondition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WinningCondition.swift; sourceTree = "<group>"; };
+		2D00812B27E617A700F0E359 /* LastStandWinningCondition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastStandWinningCondition.swift; sourceTree = "<group>"; };
+		2D00813027E6193400F0E359 /* WinnerGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WinnerGenerator.swift; sourceTree = "<group>"; };
+		2D00813527E61AA700F0E359 /* LastStandWinnerGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastStandWinnerGenerator.swift; sourceTree = "<group>"; };
 		2D00814F27E6253200F0E359 /* PlayerCollectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerCollectionTests.swift; sourceTree = "<group>"; };
+		2D00816A27E64C8A00F0E359 /* WinMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WinMessageView.swift; sourceTree = "<group>"; };
 		2D00817827E6D1CA00F0E359 /* CardCollectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardCollectionTests.swift; sourceTree = "<group>"; };
 		2DA04F2F27DADD500063D952 /* CardBox.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CardBox.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2DA04F3227DADD500063D952 /* CardBoxApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardBoxApp.swift; sourceTree = "<group>"; };
@@ -268,6 +270,8 @@
 		4ECD77E527E6E65400A48FA7 /* ActionTests+MoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ActionTests+MoreTests.swift"; sourceTree = "<group>"; };
 		4ECD77E727E70A5A00A48FA7 /* CardActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardActionTests.swift; sourceTree = "<group>"; };
 		4ECD77E927E70B2300A48FA7 /* CardActionTests+NextPlayerGeneratorStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CardActionTests+NextPlayerGeneratorStub.swift"; sourceTree = "<group>"; };
+		4ECD77EB27E73A9900A48FA7 /* CardBoxTestsUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardBoxTestsUtil.swift; sourceTree = "<group>"; };
+		4ECD77ED27E7427000A48FA7 /* CardActionTests+MoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CardActionTests+MoreTests.swift"; sourceTree = "<group>"; };
 		682AA3CC27DF1EB90034ED90 /* AddCardToPlayerAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddCardToPlayerAction.swift; sourceTree = "<group>"; };
 		68466A8E27E5061B000387B6 /* CurrentPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentPlayerView.swift; sourceTree = "<group>"; };
 		68466A9027E506C2000387B6 /* NonCurrentPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonCurrentPlayerView.swift; sourceTree = "<group>"; };
@@ -344,6 +348,15 @@
 			path = WinningConditions;
 			sourceTree = "<group>";
 		};
+		2D00814327E623C700F0E359 /* CardGameEngine */ = {
+			isa = PBXGroup;
+			children = (
+				2D00814F27E6253200F0E359 /* PlayerCollectionTests.swift */,
+				2D00817827E6D1CA00F0E359 /* CardCollectionTests.swift */,
+			);
+			path = CardGameEngine;
+			sourceTree = "<group>";
+		};
 		2D00816627E64C3600F0E359 /* RequestViews */ = {
 			isa = PBXGroup;
 			children = (
@@ -353,15 +366,6 @@
 				6868907B27E60FAF001C4C62 /* CardTypeRequestView.swift */,
 			);
 			path = RequestViews;
-			sourceTree = "<group>";
-		};
-		2D00814327E623C700F0E359 /* CardGameEngine */ = {
-			isa = PBXGroup;
-			children = (
-				2D00814F27E6253200F0E359 /* PlayerCollectionTests.swift */,
-				2D00817827E6D1CA00F0E359 /* CardCollectionTests.swift */,
-			);
-			path = CardGameEngine;
 			sourceTree = "<group>";
 		};
 		2DA04F2627DADD500063D952 = {
@@ -420,6 +424,8 @@
 				4E94E72B27E6DB01004ED4EF /* ActionTests+NextPlayerGeneratorStub.swift */,
 				4ECD77E727E70A5A00A48FA7 /* CardActionTests.swift */,
 				4ECD77E927E70B2300A48FA7 /* CardActionTests+NextPlayerGeneratorStub.swift */,
+				4ECD77ED27E7427000A48FA7 /* CardActionTests+MoreTests.swift */,
+				4ECD77EB27E73A9900A48FA7 /* CardBoxTestsUtil.swift */,
 			);
 			path = CardBoxTests;
 			sourceTree = "<group>";
@@ -878,14 +884,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-
 				4ECD77E627E6E65500A48FA7 /* ActionTests+MoreTests.swift in Sources */,
-
 				2D00815027E6253200F0E359 /* PlayerCollectionTests.swift in Sources */,
 				2D00817927E6D1CA00F0E359 /* CardCollectionTests.swift in Sources */,
-
 				2DA04F4527DADD520063D952 /* CardBoxTests.swift in Sources */,
+				4ECD77EC27E73A9900A48FA7 /* CardBoxTestsUtil.swift in Sources */,
 				4ECD77E827E70A5A00A48FA7 /* CardActionTests.swift in Sources */,
+				4ECD77EE27E7427000A48FA7 /* CardActionTests+MoreTests.swift in Sources */,
 				4ECD77EA27E70B2300A48FA7 /* CardActionTests+NextPlayerGeneratorStub.swift in Sources */,
 				4E94E72A27E6B414004ED4EF /* ActionTests.swift in Sources */,
 				4E94E72C27E6DB01004ED4EF /* ActionTests+NextPlayerGeneratorStub.swift in Sources */,

--- a/CardBox/CardGameEngine/CardActions/PlayerTakenChosenCardFromPlayerCardAction.swift
+++ b/CardBox/CardGameEngine/CardActions/PlayerTakenChosenCardFromPlayerCardAction.swift
@@ -12,7 +12,8 @@ struct PlayerTakenChosenCardFromPlayerCardAction: CardAction {
     func executeGameEvents(gameRunner: GameRunnerReadOnly, args: CardActionArgs) {
         let targetPlayerWrapped = args.target.getPlayerIfTargetSingle()
 
-        guard let targetPlayerUnwrapped = targetPlayerWrapped else {
+        guard let targetPlayerUnwrapped = targetPlayerWrapped,
+        !targetPlayerUnwrapped.isOutOfGame else {
             return
         }
 

--- a/CardBox/CardGameEngine/CardActions/PlayerTakesChosenCardFromGameplayCardAction.swift
+++ b/CardBox/CardGameEngine/CardActions/PlayerTakesChosenCardFromGameplayCardAction.swift
@@ -7,8 +7,10 @@
 
 struct PlayerTakesChosenCardFromGameplayCardAction: CardAction {
 
+    let cardPredicate: (Card) -> Bool
+
     func executeGameEvents(gameRunner: GameRunnerReadOnly, args: CardActionArgs) {
-        guard let card = args.card else {
+        guard let card = gameRunner.gameplayArea.getCard(where: cardPredicate) else {
             return
         }
         gameRunner.executeGameEvents([MoveCardGameplayToPlayerEvent(card: card, player: args.player)])

--- a/CardBox/Models/ExplodingKittens/ExplodingKittensGameRunnerInitialiser.swift
+++ b/CardBox/Models/ExplodingKittens/ExplodingKittensGameRunnerInitialiser.swift
@@ -259,8 +259,11 @@ class ExplodingKittensGameRunnerInitialiser: GameRunnerInitialiser {
                 return []
             }
 
-            // TODO: Prompt player to choose a card
-            return [PlayerTakesChosenCardFromGameplayCardAction()]
+            // TODO: Prompt player to choose a card, for now default defuse
+            return [PlayerTakesChosenCardFromGameplayCardAction(cardPredicate: {
+                ExplodingKittensUtils.getCardType(card: $0)?.rawValue ==
+                ExplodingKittensUtils.getCardType(card: generateDefuseCard())?.rawValue
+            })]
         }
 
         return fiveDifferentCards

--- a/CardBoxTests/ActionTests+MoreTests.swift
+++ b/CardBoxTests/ActionTests+MoreTests.swift
@@ -26,20 +26,9 @@ extension ActionTests {
         let initialDeck = CardCollection(cards: gameRunner.deck.getCards())
         ActionDispatcher.runAction(ShuffleDeckAction(), on: gameRunner)
         let newDeck = gameRunner.deck
-        XCTAssertFalse(areDeckSame(firstDeck: initialDeck, secondDeck: newDeck))
-    }
-
-    private func areDeckSame(firstDeck: CardCollection, secondDeck: CardCollection) -> Bool {
-        var orderIsSame = true
-
-        for index in 0 ..< gameRunner.deck.count {
-            let firstDeckCard = firstDeck.getCardByIndex(index)
-            let secondDeckCard = secondDeck.getCardByIndex(index)
-            orderIsSame = orderIsSame && firstDeckCard?.getAdditionalParams(key: cardTypeKey) ==
-            secondDeckCard?.getAdditionalParams(key: cardTypeKey)
-        }
-
-        return orderIsSame
+        XCTAssertFalse(CardBoxTestsUtil.areCardCollectionsSame(firstCardCollection: initialDeck,
+                                                               secondCardCollection: newDeck,
+                                                               gameRunner: gameRunner))
     }
 
     func test_playCardAction_leaveGameCard() throws {

--- a/CardBoxTests/ActionTests.swift
+++ b/CardBoxTests/ActionTests.swift
@@ -17,8 +17,7 @@ class ActionTests: XCTestCase {
     var noTargetCard: Card!
     var initialNumOfCardsInDeck: Int!
 
-    let cardTypeKey = "CARD_TYPE"
-
+    let cardTypeKey = CardBoxTestsUtil.cardTypeKey
     let numOfPlayers = 2
 
     lazy var cardCombo: CardCombo = { cards in

--- a/CardBoxTests/CardActionTests+MoreTests.swift
+++ b/CardBoxTests/CardActionTests+MoreTests.swift
@@ -1,0 +1,299 @@
+//
+//  CardActionTests+MoreTests.swift
+//  CardBoxTests
+//
+//  Created by Bryann Yeap Kok Keong on 20/3/22.
+//
+
+import XCTest
+@testable import CardBox
+
+extension CardActionTests {
+
+    func test_conditionalCardAction_whenTrueHasNoFalseAction() throws {
+        let currentPlayer = try XCTUnwrap(gameRunner.players.currentPlayer)
+        let initialOutOfGameStatus = currentPlayer.isOutOfGame
+
+        let condition: (GameRunnerReadOnly, Player, GameplayTarget) -> Bool  = { _, _, _ in true }
+        let isTrueActions: [CardAction] = [PlayerOutOfGameCardAction()]
+        let isFalseActions: [CardAction]? = nil
+
+        let conditionalCardAction = ConditionalCardAction(
+            condition: condition,
+            isTrueCardActions: isTrueActions,
+            isFalseCardActions: isFalseActions
+        )
+
+        let card = Card(name: "Conditional Card", typeOfTargettedCard: .noTargetCard)
+        card.addPlayAction(conditionalCardAction)
+
+        ActionDispatcher.runAction(
+            PlayCardAction(
+                player: currentPlayer,
+                cards: [card],
+                target: .none
+            ),
+            on: gameRunner
+        )
+
+        let newOutOfGameStatus = currentPlayer.isOutOfGame
+
+        XCTAssertFalse(initialOutOfGameStatus)
+        XCTAssertTrue(newOutOfGameStatus)
+    }
+
+    func test_conditionalCardAction_whenTrueHasFalseAction() throws {
+        let testKey = "TEST_KEY"
+        let testValueTrue = "TEST_VALUE_TRUE"
+        let testValueFalse = "TEST_VALUE_FALSE"
+
+        let currentPlayer = try XCTUnwrap(gameRunner.players.currentPlayer)
+
+        let condition: (GameRunnerReadOnly, Player, GameplayTarget) -> Bool  = { _, _, _ in true }
+        let isTrueActions: [CardAction] = [
+            SetPlayerAdditionalParamsCardAction(
+                playerResolver: { _ in currentPlayer },
+                key: testKey,
+                value: testValueTrue
+            )
+        ]
+        let isFalseActions: [CardAction]? = [
+            SetPlayerAdditionalParamsCardAction(
+                playerResolver: { _ in currentPlayer },
+                key: testKey,
+                value: testValueFalse
+            )
+        ]
+        let conditionalCardAction = ConditionalCardAction(
+            condition: condition,
+            isTrueCardActions: isTrueActions,
+            isFalseCardActions: isFalseActions
+        )
+
+        let card = Card(name: "Conditional Card", typeOfTargettedCard: .noTargetCard)
+        card.addPlayAction(conditionalCardAction)
+
+        XCTAssertNotEqual(currentPlayer.getAdditionalParams(key: testKey), testValueTrue)
+        XCTAssertNotEqual(currentPlayer.getAdditionalParams(key: testKey), testValueFalse)
+
+        ActionDispatcher.runAction(
+            PlayCardAction(
+                player: currentPlayer,
+                cards: [card],
+                target: .none
+            ),
+            on: gameRunner
+        )
+
+        XCTAssertEqual(currentPlayer.getAdditionalParams(key: testKey), testValueTrue)
+        XCTAssertNotEqual(currentPlayer.getAdditionalParams(key: testKey), testValueFalse)
+    }
+
+    func test_conditionalCardAction_whenFalse() throws {
+        let testKey = "TEST_KEY"
+        let testValueTrue = "TEST_VALUE_TRUE"
+        let testValueFalse = "TEST_VALUE_FALSE"
+
+        let currentPlayer = try XCTUnwrap(gameRunner.players.currentPlayer)
+
+        let condition: (GameRunnerReadOnly, Player, GameplayTarget) -> Bool  = { _, _, _ in false }
+        let isTrueActions: [CardAction] = [
+            SetPlayerAdditionalParamsCardAction(
+                playerResolver: { _ in currentPlayer },
+                key: testKey,
+                value: testValueTrue
+            )
+        ]
+        let isFalseActions: [CardAction]? = [
+            SetPlayerAdditionalParamsCardAction(
+                playerResolver: { _ in currentPlayer },
+                key: testKey,
+                value: testValueFalse
+            )
+        ]
+        let conditionalCardAction = ConditionalCardAction(
+            condition: condition,
+            isTrueCardActions: isTrueActions,
+            isFalseCardActions: isFalseActions
+        )
+
+        let card = Card(name: "Conditional Card", typeOfTargettedCard: .noTargetCard)
+        card.addPlayAction(conditionalCardAction)
+
+        XCTAssertNotEqual(currentPlayer.getAdditionalParams(key: testKey), testValueTrue)
+        XCTAssertNotEqual(currentPlayer.getAdditionalParams(key: testKey), testValueFalse)
+
+        ActionDispatcher.runAction(
+            PlayCardAction(
+                player: currentPlayer,
+                cards: [card],
+                target: .none
+            ),
+            on: gameRunner
+        )
+
+        XCTAssertNotEqual(currentPlayer.getAdditionalParams(key: testKey), testValueTrue)
+        XCTAssertEqual(currentPlayer.getAdditionalParams(key: testKey), testValueFalse)
+    }
+
+    func test_playerTakesNthCardFromPlayerCardAction_targetPlayerHasAtLeastNCards() throws {
+        let n = 0
+        let currentPlayer = try XCTUnwrap(gameRunner.players.currentPlayer)
+        gameRunner.advanceToNextPlayer()
+        let nextPlayer = try XCTUnwrap(gameRunner.players.currentPlayer)
+        gameRunner.advanceToNextPlayer()
+        nextPlayer.addCard(singleTargetCard)
+
+        XCTAssertFalse(currentPlayer.hasCard(singleTargetCard))
+        XCTAssertTrue(nextPlayer.hasCard(singleTargetCard))
+
+        let takeNthCard = Card(name: "Take Nth", typeOfTargettedCard: .targetSinglePlayerCard)
+        takeNthCard.addPlayAction(PlayerTakesNthCardFromPlayerCardAction(n: n, stateOfN: .given))
+
+        ActionDispatcher.runAction(
+            PlayCardAction(
+                player: currentPlayer,
+                cards: [takeNthCard],
+                target: .single(nextPlayer)),
+            on: gameRunner
+        )
+
+        XCTAssertTrue(currentPlayer.hasCard(singleTargetCard))
+        XCTAssertFalse(nextPlayer.hasCard(singleTargetCard))
+    }
+
+    func test_playerTakesNthCardFromPlayerCardAction_targetPlayerHasLessThanNCards() throws {
+        let n = 1
+        let currentPlayer = try XCTUnwrap(gameRunner.players.currentPlayer)
+        gameRunner.advanceToNextPlayer()
+        let nextPlayer = try XCTUnwrap(gameRunner.players.currentPlayer)
+        gameRunner.advanceToNextPlayer()
+        nextPlayer.addCard(noTargetCard)
+
+        XCTAssertFalse(currentPlayer.hasCard(noTargetCard))
+        XCTAssertTrue(nextPlayer.hasCard(noTargetCard))
+
+        let takeNthCard = Card(name: "Take Nth", typeOfTargettedCard: .targetSinglePlayerCard)
+        takeNthCard.addPlayAction(PlayerTakesNthCardFromPlayerCardAction(n: n, stateOfN: .given))
+
+        ActionDispatcher.runAction(
+            PlayCardAction(
+                player: currentPlayer,
+                cards: [takeNthCard],
+                target: .single(nextPlayer)),
+            on: gameRunner
+        )
+
+        XCTAssertFalse(currentPlayer.hasCard(noTargetCard))
+        XCTAssertTrue(nextPlayer.hasCard(noTargetCard))
+    }
+
+    func test_playerTakesNthCardFromPlayerCardAction_targetPlayerOutOfGame() throws {
+        let n = 0
+        let currentPlayer = try XCTUnwrap(gameRunner.players.currentPlayer)
+        gameRunner.advanceToNextPlayer()
+        let nextPlayer = try XCTUnwrap(gameRunner.players.currentPlayer)
+        gameRunner.advanceToNextPlayer()
+        nextPlayer.addCard(singleTargetCard)
+        nextPlayer.setOutOfGame(true)
+
+        XCTAssertFalse(currentPlayer.hasCard(singleTargetCard))
+        XCTAssertFalse(nextPlayer.hasCard(singleTargetCard))
+
+        let takeNthCard = Card(name: "Take Nth", typeOfTargettedCard: .targetSinglePlayerCard)
+        takeNthCard.addPlayAction(PlayerTakesNthCardFromPlayerCardAction(n: n, stateOfN: .given))
+
+        ActionDispatcher.runAction(
+            PlayCardAction(
+                player: currentPlayer,
+                cards: [takeNthCard],
+                target: .single(nextPlayer)),
+            on: gameRunner
+        )
+
+        XCTAssertFalse(currentPlayer.hasCard(singleTargetCard))
+        XCTAssertFalse(nextPlayer.hasCard(singleTargetCard))
+    }
+
+    func test_playerTakesNthCardFromPlayerCardAction_randomN() throws {
+        let currentPlayer = try XCTUnwrap(gameRunner.players.currentPlayer)
+        gameRunner.advanceToNextPlayer()
+        let nextPlayer = try XCTUnwrap(gameRunner.players.currentPlayer)
+        gameRunner.advanceToNextPlayer()
+        nextPlayer.addCard(singleTargetCard)
+
+        XCTAssertFalse(currentPlayer.hasCard(singleTargetCard))
+        XCTAssertTrue(nextPlayer.hasCard(singleTargetCard))
+
+        let takeNthCard = Card(name: "Take Nth", typeOfTargettedCard: .targetSinglePlayerCard)
+        takeNthCard.addPlayAction(PlayerTakesNthCardFromPlayerCardAction(n: -1, stateOfN: .random))
+
+        ActionDispatcher.runAction(
+            PlayCardAction(
+                player: currentPlayer,
+                cards: [takeNthCard],
+                target: .single(nextPlayer)),
+            on: gameRunner
+        )
+
+        XCTAssertTrue(currentPlayer.hasCard(singleTargetCard))
+        XCTAssertFalse(nextPlayer.hasCard(singleTargetCard))
+    }
+
+    func test_playerTakesChosenCardFromGameplayAction_gameplayHasCard() throws {
+        let cardToChoose: Card = noTargetCard
+        let cardToChoosePredicate: (Card) -> Bool = { card in
+            card.getAdditionalParams(key: self.cardTypeKey) == cardToChoose.getAdditionalParams(key: self.cardTypeKey)
+        }
+        let currentPlayer = try XCTUnwrap(gameRunner.players.currentPlayer)
+        let gameplayArea = gameRunner.gameplayArea
+        gameplayArea.addCard(cardToChoose)
+
+        XCTAssertFalse(currentPlayer.hasCard(where: cardToChoosePredicate))
+        XCTAssertTrue(gameplayArea.containsCard(where: cardToChoosePredicate))
+
+        let chooseCard = Card(name: "Choose", typeOfTargettedCard: .targetSinglePlayerCard)
+        chooseCard.addPlayAction(
+            PlayerTakesChosenCardFromGameplayCardAction(cardPredicate: cardToChoosePredicate)
+        )
+
+        ActionDispatcher.runAction(
+            PlayCardAction(
+                player: currentPlayer,
+                cards: [chooseCard],
+                target: .none),
+            on: gameRunner
+        )
+
+        XCTAssertTrue(currentPlayer.hasCard(where: cardToChoosePredicate))
+        XCTAssertFalse(gameplayArea.containsCard(where: cardToChoosePredicate))
+    }
+
+    func test_playerTakesChosenCardFromGameplayCardAction_gameplayDoesNotHaveCard() throws {
+        let cardToChoose: Card = noTargetCard
+        let cardToChoosePredicate: (Card) -> Bool = { card in
+            card.getAdditionalParams(key: self.cardTypeKey) == cardToChoose.getAdditionalParams(key: self.cardTypeKey)
+        }
+        let currentPlayer = try XCTUnwrap(gameRunner.players.currentPlayer)
+        let gameplayArea = gameRunner.gameplayArea
+
+        XCTAssertFalse(currentPlayer.hasCard(where: cardToChoosePredicate))
+        XCTAssertFalse(gameplayArea.containsCard(where: cardToChoosePredicate))
+
+        let chooseCard = Card(name: "Choose", typeOfTargettedCard: .targetSinglePlayerCard)
+        chooseCard.addPlayAction(
+            PlayerTakesChosenCardFromGameplayCardAction(cardPredicate: cardToChoosePredicate)
+        )
+
+        ActionDispatcher.runAction(
+            PlayCardAction(
+                player: currentPlayer,
+                cards: [chooseCard],
+                target: .none),
+            on: gameRunner
+        )
+
+        XCTAssertFalse(currentPlayer.hasCard(where: cardToChoosePredicate))
+        XCTAssertFalse(gameplayArea.containsCard(where: cardToChoosePredicate))
+    }
+}

--- a/CardBoxTests/CardActionTests+MoreTests.swift
+++ b/CardBoxTests/CardActionTests+MoreTests.swift
@@ -165,13 +165,12 @@ extension CardActionTests {
     func test_playerTakesNthCardFromPlayerCardAction_targetPlayerHasLessThanNCards() throws {
         let n = 1
         let currentPlayer = try XCTUnwrap(gameRunner.players.currentPlayer)
+        let initialCurrentPlayerHand = CardCollection(cards: currentPlayer.getHand().getCards())
         gameRunner.advanceToNextPlayer()
         let nextPlayer = try XCTUnwrap(gameRunner.players.currentPlayer)
-        gameRunner.advanceToNextPlayer()
         nextPlayer.addCard(noTargetCard)
-
-        XCTAssertFalse(currentPlayer.hasCard(noTargetCard))
-        XCTAssertTrue(nextPlayer.hasCard(noTargetCard))
+        let initialNextPlayerHand = CardCollection(cards: nextPlayer.getHand().getCards())
+        gameRunner.advanceToNextPlayer()
 
         let takeNthCard = Card(name: "Take Nth", typeOfTargettedCard: .targetSinglePlayerCard)
         takeNthCard.addPlayAction(PlayerTakesNthCardFromPlayerCardAction(n: n, stateOfN: .given))
@@ -184,8 +183,12 @@ extension CardActionTests {
             on: gameRunner
         )
 
-        XCTAssertFalse(currentPlayer.hasCard(noTargetCard))
-        XCTAssertTrue(nextPlayer.hasCard(noTargetCard))
+        XCTAssertTrue(CardBoxTestsUtil.areCardCollectionsSame(firstCardCollection: initialCurrentPlayerHand,
+                                                              secondCardCollection: currentPlayer.getHand(),
+                                                              gameRunner: gameRunner))
+        XCTAssertTrue(CardBoxTestsUtil.areCardCollectionsSame(firstCardCollection: initialNextPlayerHand,
+                                                              secondCardCollection: nextPlayer.getHand(),
+                                                              gameRunner: gameRunner))
     }
 
     func test_playerTakesNthCardFromPlayerCardAction_targetPlayerOutOfGame() throws {

--- a/CardBoxTests/CardActionTests+MoreTests.swift
+++ b/CardBoxTests/CardActionTests+MoreTests.swift
@@ -194,14 +194,13 @@ extension CardActionTests {
     func test_playerTakesNthCardFromPlayerCardAction_targetPlayerOutOfGame() throws {
         let n = 0
         let currentPlayer = try XCTUnwrap(gameRunner.players.currentPlayer)
+        let initialCurrentPlayerHand = CardCollection(cards: currentPlayer.getHand().getCards())
         gameRunner.advanceToNextPlayer()
         let nextPlayer = try XCTUnwrap(gameRunner.players.currentPlayer)
-        gameRunner.advanceToNextPlayer()
         nextPlayer.addCard(singleTargetCard)
+        let initialNextPlayerHand = CardCollection(cards: nextPlayer.getHand().getCards())
+        gameRunner.advanceToNextPlayer()
         nextPlayer.setOutOfGame(true)
-
-        XCTAssertFalse(currentPlayer.hasCard(singleTargetCard))
-        XCTAssertFalse(nextPlayer.hasCard(singleTargetCard))
 
         let takeNthCard = Card(name: "Take Nth", typeOfTargettedCard: .targetSinglePlayerCard)
         takeNthCard.addPlayAction(PlayerTakesNthCardFromPlayerCardAction(n: n, stateOfN: .given))
@@ -214,8 +213,12 @@ extension CardActionTests {
             on: gameRunner
         )
 
-        XCTAssertFalse(currentPlayer.hasCard(singleTargetCard))
-        XCTAssertFalse(nextPlayer.hasCard(singleTargetCard))
+        XCTAssertTrue(CardBoxTestsUtil.areCardCollectionsSame(firstCardCollection: initialCurrentPlayerHand,
+                                                              secondCardCollection: currentPlayer.getHand(),
+                                                              gameRunner: gameRunner))
+        XCTAssertTrue(CardBoxTestsUtil.areCardCollectionsSame(firstCardCollection: initialNextPlayerHand,
+                                                              secondCardCollection: nextPlayer.getHand(),
+                                                              gameRunner: gameRunner))
     }
 
     func test_playerTakesNthCardFromPlayerCardAction_randomN() throws {

--- a/CardBoxTests/CardActionTests.swift
+++ b/CardBoxTests/CardActionTests.swift
@@ -202,32 +202,6 @@ extension CardActionTests {
         XCTAssertFalse(nextPlayer.hasCard(where: cardToChoosePredicate))
     }
 
-    func test_playerInsertCardIntoDeckCard_playerHasCard() throws {
-        let currentPlayer = try XCTUnwrap(gameRunner.players.currentPlayer)
-        let n = 3
-        let initialNthCardInDeck = gameRunner.deck.getCardByIndex(n)
-
-        let card = Card(name: "Insert Card Into Deck", typeOfTargettedCard: .noTargetCard)
-        card.addPlayAction(PlayerInsertCardIntoDeckCardAction(offsetFromTop: 3))
-        currentPlayer.addCard(card)
-
-        ActionDispatcher.runAction(
-            PlayCardAction(
-                player: currentPlayer,
-                cards: [card],
-                target: .none),
-            on: gameRunner
-        )
-
-        let newNthCardInDeck = gameRunner.deck.getCardByIndex(n)
-
-        XCTAssertEqual(gameRunner.deck.count, initialNumOfCardsInDeck + 1)
-        XCTAssertNotEqual(initialNthCardInDeck?.getAdditionalParams(key: cardTypeKey),
-                          newNthCardInDeck?.getAdditionalParams(key: cardTypeKey))
-        XCTAssertEqual(newNthCardInDeck?.getAdditionalParams(key: cardTypeKey),
-                       card.getAdditionalParams(key: cardTypeKey))
-    }
-
     func test_playerDiscardCardAction_playerHasCard() throws {
         let currentPlayer = try XCTUnwrap(gameRunner.players.currentPlayer)
         let cardToDiscard: Card = allTargetCard
@@ -279,6 +253,32 @@ extension CardActionTests {
         XCTAssertTrue(CardBoxTestsUtil.areCardCollectionsSame(firstCardCollection: initialCurrentPlayerHand,
                                                               secondCardCollection: newCurrentPlayerHand,
                                                               gameRunner: gameRunner))
+    }
+
+    func test_playerInsertCardIntoDeckCard_playerHasCard() throws {
+        let currentPlayer = try XCTUnwrap(gameRunner.players.currentPlayer)
+        let n = 3
+        let initialNthCardInDeck = gameRunner.deck.getCardByIndex(n)
+
+        let card = Card(name: "Insert Card Into Deck", typeOfTargettedCard: .noTargetCard)
+        card.addPlayAction(PlayerInsertCardIntoDeckCardAction(offsetFromTop: 3))
+        currentPlayer.addCard(card)
+
+        ActionDispatcher.runAction(
+            PlayCardAction(
+                player: currentPlayer,
+                cards: [card],
+                target: .none),
+            on: gameRunner
+        )
+
+        let newNthCardInDeck = gameRunner.deck.getCardByIndex(n)
+
+        XCTAssertEqual(gameRunner.deck.count, initialNumOfCardsInDeck + 1)
+        XCTAssertNotEqual(initialNthCardInDeck?.getAdditionalParams(key: cardTypeKey),
+                          newNthCardInDeck?.getAdditionalParams(key: cardTypeKey))
+        XCTAssertEqual(newNthCardInDeck?.getAdditionalParams(key: cardTypeKey),
+                       card.getAdditionalParams(key: cardTypeKey))
     }
 
     func test_playerInsertCardIntoDeckCard_playerDoesNotHaveCard() throws {

--- a/CardBoxTests/CardActionTests.swift
+++ b/CardBoxTests/CardActionTests.swift
@@ -12,23 +12,25 @@ class CardActionTests: XCTestCase {
 
     var gameRunner: GameRunner!
 
-    let cardTypeKey = "CARD_TYPE"
-
-//    var singleTargetCard: Card!
-//    var allTargetCard: Card!
-//    var noTargetCard: Card!
+    var singleTargetCard: Card!
+    var allTargetCard: Card!
+    var noTargetCard: Card!
     var initialNumOfCardsInDeck: Int!
 
+    let cardTypeKey = CardBoxTestsUtil.cardTypeKey
     let numOfPlayers = 2
 
     override func setUpWithError() throws {
         try super.setUpWithError()
         gameRunner = getAndSetupGameRunnerInstance()
-//        singleTargetCard = generateSingleTargetCard()
-//        allTargetCard = generateAllTargetCard()
-//        noTargetCard = generateNoTargetCard()
+        singleTargetCard = generateSingleTargetCard()
+        allTargetCard = generateAllTargetCard()
+        noTargetCard = generateNoTargetCard()
         initialNumOfCardsInDeck = gameRunner.deck.count
     }
+}
+
+extension CardActionTests {
 
     func test_PlayerOutOfGameCardAction_initiallyNotOutOfGamePlayer() throws {
         let currentPlayer = try XCTUnwrap(gameRunner.players.currentPlayer)
@@ -110,9 +112,98 @@ class CardActionTests: XCTestCase {
         XCTAssertTrue(isSamePlayers(initialCurrentPlayer, newCurrentPlayer))
     }
 
+    func test_playerTakesChosenCardFromPlayerCardAction_targetPlayerHasCard() throws {
+        let cardToChoose: Card = singleTargetCard
+        let cardToChoosePredicate: (Card) -> Bool = { card in
+            card.getAdditionalParams(key: self.cardTypeKey) == cardToChoose.getAdditionalParams(key: self.cardTypeKey)
+        }
+
+        let currentPlayer = try XCTUnwrap(gameRunner.players.currentPlayer)
+        gameRunner.advanceToNextPlayer()
+        let nextPlayer = try XCTUnwrap(gameRunner.players.currentPlayer)
+        gameRunner.advanceToNextPlayer()
+        nextPlayer.addCard(cardToChoose)
+
+        XCTAssertFalse(currentPlayer.hasCard(where: cardToChoosePredicate))
+        XCTAssertTrue(nextPlayer.hasCard(where: cardToChoosePredicate))
+
+        let chooseCard = Card(name: "Choose", typeOfTargettedCard: .targetSinglePlayerCard)
+        chooseCard.addPlayAction(PlayerTakenChosenCardFromPlayerCardAction(cardPredicate: cardToChoosePredicate))
+
+        ActionDispatcher.runAction(
+            PlayCardAction(
+                player: currentPlayer,
+                cards: [chooseCard],
+                target: .single(nextPlayer)),
+            on: gameRunner
+        )
+
+        XCTAssertTrue(currentPlayer.hasCard(where: cardToChoosePredicate))
+        XCTAssertFalse(nextPlayer.hasCard(where: cardToChoosePredicate))
+    }
+
+    func test_playerTakesChosenCardFromPlayerCardAction_targetPlayerDoesNotHaveCard() throws {
+        let cardToChoose: Card = singleTargetCard
+        let cardToChoosePredicate: (Card) -> Bool = { card in
+            card.getAdditionalParams(key: self.cardTypeKey) == cardToChoose.getAdditionalParams(key: self.cardTypeKey)
+        }
+
+        let currentPlayer = try XCTUnwrap(gameRunner.players.currentPlayer)
+        gameRunner.advanceToNextPlayer()
+        let nextPlayer = try XCTUnwrap(gameRunner.players.currentPlayer)
+        gameRunner.advanceToNextPlayer()
+
+        XCTAssertFalse(currentPlayer.hasCard(where: cardToChoosePredicate))
+        XCTAssertFalse(nextPlayer.hasCard(where: cardToChoosePredicate))
+
+        let chooseCard = Card(name: "Choose", typeOfTargettedCard: .targetSinglePlayerCard)
+        chooseCard.addPlayAction(PlayerTakenChosenCardFromPlayerCardAction(cardPredicate: cardToChoosePredicate))
+
+        ActionDispatcher.runAction(
+            PlayCardAction(
+                player: currentPlayer,
+                cards: [chooseCard],
+                target: .single(nextPlayer)),
+            on: gameRunner
+        )
+
+        XCTAssertFalse(currentPlayer.hasCard(where: cardToChoosePredicate))
+        XCTAssertFalse(nextPlayer.hasCard(where: cardToChoosePredicate))
+    }
+
+    func test_playerTakesChosenCardFromPlayerCardAction_targetPlayerOutOfGame() throws {
+        let cardToChoose: Card = singleTargetCard
+        let cardToChoosePredicate: (Card) -> Bool = { card in
+            card.getAdditionalParams(key: self.cardTypeKey) == cardToChoose.getAdditionalParams(key: self.cardTypeKey)
+        }
+
+        let currentPlayer = try XCTUnwrap(gameRunner.players.currentPlayer)
+        gameRunner.advanceToNextPlayer()
+        let nextPlayer = try XCTUnwrap(gameRunner.players.currentPlayer)
+        gameRunner.advanceToNextPlayer()
+        nextPlayer.addCard(cardToChoose)
+        nextPlayer.setOutOfGame(true)
+
+        XCTAssertFalse(currentPlayer.hasCard(where: cardToChoosePredicate))
+        XCTAssertFalse(nextPlayer.hasCard(where: cardToChoosePredicate))
+
+        let chooseCard = Card(name: "Choose", typeOfTargettedCard: .targetSinglePlayerCard)
+        chooseCard.addPlayAction(PlayerTakenChosenCardFromPlayerCardAction(cardPredicate: cardToChoosePredicate))
+
+        ActionDispatcher.runAction(
+            PlayCardAction(
+                player: currentPlayer,
+                cards: [chooseCard],
+                target: .single(nextPlayer)),
+            on: gameRunner
+        )
+
+        XCTAssertFalse(currentPlayer.hasCard(where: cardToChoosePredicate))
+        XCTAssertFalse(nextPlayer.hasCard(where: cardToChoosePredicate))
+    }
+
     func test_playerInsertCardIntoDeckCard_playerHasCard() throws {
         let currentPlayer = try XCTUnwrap(gameRunner.players.currentPlayer)
-
         let n = 3
         let initialNthCardInDeck = gameRunner.deck.getCardByIndex(n)
 
@@ -135,6 +226,59 @@ class CardActionTests: XCTestCase {
                           newNthCardInDeck?.getAdditionalParams(key: cardTypeKey))
         XCTAssertEqual(newNthCardInDeck?.getAdditionalParams(key: cardTypeKey),
                        card.getAdditionalParams(key: cardTypeKey))
+    }
+
+    func test_playerDiscardCardAction_playerHasCard() throws {
+        let currentPlayer = try XCTUnwrap(gameRunner.players.currentPlayer)
+        let cardToDiscard: Card = allTargetCard
+        currentPlayer.addCard(cardToDiscard)
+        let initialCurrentPlayerHand = CardCollection(cards: currentPlayer.getHand().getCards())
+        let cardToDiscardCondition: (Card) -> Bool = { [self] card in
+            card.getAdditionalParams(key: cardTypeKey) == cardToDiscard.getAdditionalParams(key: cardTypeKey)
+        }
+        let card = Card(name: "Discard", typeOfTargettedCard: .noTargetCard)
+        card.addPlayAction(PlayerDiscardCardAction(where: cardToDiscardCondition))
+
+        ActionDispatcher.runAction(
+            PlayCardAction(
+                player: currentPlayer,
+                cards: [card],
+                target: .none),
+            on: gameRunner
+        )
+
+        let newCurrentPlayerHand = currentPlayer.getHand()
+
+        XCTAssertEqual(newCurrentPlayerHand.count, initialCurrentPlayerHand.count - 1)
+        XCTAssertFalse(CardBoxTestsUtil.areCardCollectionsSame(firstCardCollection: initialCurrentPlayerHand,
+                                                               secondCardCollection: newCurrentPlayerHand,
+                                                               gameRunner: gameRunner))
+    }
+
+    func test_playerDiscardCardAction_playerDoesNotHaveCard() throws {
+        let currentPlayer = try XCTUnwrap(gameRunner.players.currentPlayer)
+        let cardToDiscard: Card = allTargetCard
+        let initialCurrentPlayerHand = CardCollection(cards: currentPlayer.getHand().getCards())
+        let cardToDiscardCondition: (Card) -> Bool = { [self] card in
+            card.getAdditionalParams(key: cardTypeKey) == cardToDiscard.getAdditionalParams(key: cardTypeKey)
+        }
+        let card = Card(name: "Discard", typeOfTargettedCard: .noTargetCard)
+        card.addPlayAction(PlayerDiscardCardAction(where: cardToDiscardCondition))
+
+        ActionDispatcher.runAction(
+            PlayCardAction(
+                player: currentPlayer,
+                cards: [card],
+                target: .none),
+            on: gameRunner
+        )
+
+        let newCurrentPlayerHand = currentPlayer.getHand()
+
+        XCTAssertEqual(newCurrentPlayerHand.count, initialCurrentPlayerHand.count)
+        XCTAssertTrue(CardBoxTestsUtil.areCardCollectionsSame(firstCardCollection: initialCurrentPlayerHand,
+                                                              secondCardCollection: newCurrentPlayerHand,
+                                                              gameRunner: gameRunner))
     }
 
     func test_playerInsertCardIntoDeckCard_playerDoesNotHaveCard() throws {
@@ -162,36 +306,51 @@ class CardActionTests: XCTestCase {
                           card.getAdditionalParams(key: cardTypeKey))
     }
 
-    func test_conditionalCardAction_whenTrueHasNoFalseAction() throws {
+    func test_setPlayerAdditionalParamsCardAction_playerResolverResolvesNotNil() throws {
+        let testKey = "TEST_KEY"
+        let testValue = "TEST_VALUE"
         let currentPlayer = try XCTUnwrap(gameRunner.players.currentPlayer)
-        let initialOutOfGameStatus = currentPlayer.isOutOfGame
-
-        let condition: (GameRunnerReadOnly, Player, GameplayTarget) -> Bool  = { _, _, _ in true }
-        let isTrueActions: [CardAction] = [PlayerOutOfGameCardAction()]
-        let isFalseActions: [CardAction]? = nil
-
-        let conditionalCardAction = ConditionalCardAction(
-            condition: condition,
-            isTrueCardActions: isTrueActions,
-            isFalseCardActions: isFalseActions
+        let card = Card(name: "Set Params", typeOfTargettedCard: .noTargetCard)
+        card.addPlayAction(SetPlayerAdditionalParamsCardAction(
+            playerResolver: { _ in currentPlayer },
+            key: testKey,
+            value: testValue)
         )
 
-        let card = Card(name: "Conditional Card", typeOfTargettedCard: .noTargetCard)
-        card.addPlayAction(conditionalCardAction)
+        XCTAssertNotEqual(currentPlayer.getAdditionalParams(key: testKey), testValue)
 
         ActionDispatcher.runAction(
             PlayCardAction(
                 player: currentPlayer,
                 cards: [card],
-                target: .none
-            ),
+                target: .none),
             on: gameRunner
         )
 
-        let newOutOfGameStatus = currentPlayer.isOutOfGame
-
-        XCTAssertFalse(initialOutOfGameStatus)
-        XCTAssertTrue(newOutOfGameStatus)
+        XCTAssertEqual(currentPlayer.getAdditionalParams(key: testKey), testValue)
     }
 
+    func test_setPlayerAdditionalParamsCardAction_playerResolverResolvesNil() throws {
+        let testKey = "TEST_KEY"
+        let testValue = "TEST_VALUE"
+        let currentPlayer = try XCTUnwrap(gameRunner.players.currentPlayer)
+        let card = Card(name: "Set Params", typeOfTargettedCard: .noTargetCard)
+        card.addPlayAction(SetPlayerAdditionalParamsCardAction(
+            playerResolver: { _ in nil },
+            key: testKey,
+            value: testValue)
+        )
+
+        XCTAssertNotEqual(currentPlayer.getAdditionalParams(key: testKey), testValue)
+
+        ActionDispatcher.runAction(
+            PlayCardAction(
+                player: currentPlayer,
+                cards: [card],
+                target: .none),
+            on: gameRunner
+        )
+
+        XCTAssertNotEqual(currentPlayer.getAdditionalParams(key: testKey), testValue)
+    }
 }

--- a/CardBoxTests/CardBoxTestsUtil.swift
+++ b/CardBoxTests/CardBoxTestsUtil.swift
@@ -1,0 +1,28 @@
+//
+//  CardBoxTestsUtil.swift
+//  CardBoxTests
+//
+//  Created by Bryann Yeap Kok Keong on 20/3/22.
+//
+
+@testable import CardBox
+
+struct CardBoxTestsUtil {
+
+    static let cardTypeKey = "CARD_TYPE"
+
+    static func areCardCollectionsSame(firstCardCollection: CardCollection,
+                                       secondCardCollection: CardCollection,
+                                       gameRunner: GameRunnerReadOnly) -> Bool {
+        var orderIsSame = true
+
+        for index in 0 ..< gameRunner.deck.count {
+            let firstDeckCard = firstCardCollection.getCardByIndex(index)
+            let secondDeckCard = secondCardCollection.getCardByIndex(index)
+            orderIsSame = orderIsSame && firstDeckCard?.getAdditionalParams(key: cardTypeKey) ==
+            secondDeckCard?.getAdditionalParams(key: cardTypeKey)
+        }
+
+        return orderIsSame
+    }
+}


### PR DESCRIPTION
### CardAction Tests

### `PlayerTakesChosenCardFromPlayerCardAction`
* Test target player has chosen card
    - Results: Current player initially did not have chosen card, target player initially has chosen card. After the card action is run, current player now has the chosen card (incrementing current player hand count by 1), and target player no longer has chosen card (decrementing target player hand count by 1) 
* Test target player does not have chosen card
    - Results: Current player and target player both initially do not have chosen card. After the card action is run, current player and target player hand both stay unchanged 
* Test target player has card, but is out of game
    - Results: Current player initially did not have chosen card, target player initially has chosen card. However, since target player is out of game, after the card action is run, current player and target player hand both stay unchanged 

### `PlayerDiscardCardAction`
* Test player has card that player wants to discard
    - Results: Player initially has card to be discarded. After the card action is run, player no longer has card to be discarded (decrementing the player's hand count by 1)
* Test player do not have card that player wants to discard
    - Results: Player initially do not have card to be discarded. After the card action is run, player's hand remains unchanged
 
### `SetPlayerAdditionalParamsCardAction`
* Test the argument `playerResolver` returning current player
    - Results: Current player additional params was successfully set
* Test the argument `playerResolver` returning a nil `Player?`
    - Results: No additional params was set   

### `PlayerTakesNthCardFromPlayerCardAction`
* Test target player has at least n cards
    - Results: Current player initially did not have nth card, target player initially has nth card. After the card action is run, current player now has the chosen nth card (incrementing current player hand count by 1), and target player no longer has previously owned nth card (decrementing target player hand count by 1) 
* Test target player has less than n cards
    - Results: After the card action is run, current player and target player hand both stay unchanged 
* Test target player has card, but is out of game
    - Results: Current player initially did not have nth card, target player initially has nth card. However, since target player is out of game, after the card action is run, current player and target player hand both stay unchanged 
* Test N is random
    - Current player initially did not has no cards, target player initially has 1 card. After the card action is run, current player now has the 1 card from target player (incrementing current player hand count by 1), and target player no longer has the previously owned 1 card (decrementing target player hand count by 1). Even though N is random, since target player only has 1 card, this test is still deterministic

### `PlayerTakesChosenCardFromGameplayCardAction`
* Test gameplay area has card
    - Results: Current player initially did not have chosen card, gameplay area initially has chosen card. After the card action is run, current player now has the chosen card (incrementing current player hand count by 1), and gameplay area no longer has chosen card (decrementing gameplay area deck count by 1) 
* Test gameplay area does not have card
    - Results: Current player and gameplay area both initially do not have chosen card. After the card action is run, current player hand and gameplay area deck both stay unchanged 